### PR TITLE
Make passing child directories as bash args work

### DIFF
--- a/rename.py
+++ b/rename.py
@@ -1,4 +1,4 @@
-from os import listdir, rename, getcwd
+from os import listdir, rename, getcwd, chdir
 from os.path import isfile, join
 import re
 import json
@@ -99,7 +99,7 @@ def main():
 
     if len(video_files) == 0:
         print("No mkv files found in directory \"{}\"".format(args["directory"]))
-
+    chdir(args["directory"])
     for file in video_files:
         try:
             new_episode_name = generate_new_name_for_episode(file)


### PR DESCRIPTION
Allows end user to be in a parent directory (i.e. "One Pace") and then perform the rename task against each child directory (after loading json files from parent)

```bash
for f in ./*; do
    if [ -d "$f" ]; then
        python rename.py -d "$f"
    fi
done
```