### PR TITLE
Search sub-directory folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For Plex to be able to fetch the metadata of the episodes, we need to rename the
 6.  If not done in step 2.2, move the resulting mkv files in their respective arc directory (or all in the `One Piece [tvdb4-81797]` directory if you don't care about organizing your files)
 
 ### 2.5 File Renaming - With a directory structure
-If the files are already in their respective folder structure (see step 1) you can use the `-sd` or `--sub-dir` flag to inform the script to search sub directories
+If the files are already in their respective folder structure (see step 1) you can use the `-r` or `--recurse` flag to inform the script to search sub directories
 1.  Open a shell/powershell terminal.
 
 2.  Change directory to the directory that contains your folder structure (e.g. `One Piece [tvdb4-81797]`)
@@ -85,8 +85,8 @@ If the files are already in their respective folder structure (see step 1) you c
 
 4.  Run the script in dry-run mode with the subdirectory flag to see what change would occur
 
-    1.  If you did step 3: `python rename.py -sd --dry-run`
-    2.  Or specify directory `python rename.py -d "/path/to/one/pace/files" -sd --dry-run`
+    1.  If you did step 3: `python rename.py -r --dry-run`
+    2.  Or specify directory `python rename.py -d "/path/to/one/pace/files" -r --dry-run`
 
 5.  Once you are okay with the changes you see, remove the `--dry-run` flag from the command and run it again.
     Your files will be renamed to the corresponding One Piece epidode, eg:

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ I highly recommend to have a look at Absolute-Series-Scanner/HAMA plugin as they
 
 3. In each arc directory, place the `tvdb4.mapping` file. (You could also not use the arcs directory and keep all you episodes in the same folder, and have the `tvdb4.mapping` directly in the `One Piece [tvdb4-81797]` folder)
 
-### 2. File renaming
+### 2. File renaming - No Directories
 For Plex to be able to fetch the metadata of the episodes, we need to rename them to something that can be matched via the HAMA agent.
 1.  Open a shell/powershell terminal.
 
-2.  Change directory to the place where you One Pace mkv files are: `cd /path/to/my/mkv/folder`
+2.  Change directory to the place where your One Pace mkv files are: `cd /path/to/my/mkv/folder`
     To make your life easier, you might want to move those files in the relevant arc directory before renaming.
 
 3.  Copy the `rename.py` and `episodes-reference.json` and `chapters-reference.json` file in that directory
@@ -74,6 +74,25 @@ For Plex to be able to fetch the metadata of the episodes, we need to rename the
     - `[One Pace] Chapter 700-701 [720p][2A35B710].mkv` -> `One.Piece.E628-E630.720p.mkv`
 
 6.  If not done in step 2.2, move the resulting mkv files in their respective arc directory (or all in the `One Piece [tvdb4-81797]` directory if you don't care about organizing your files)
+
+### 2.5 File Renaming - With a directory structure
+If the files are already in their respective folder structure (see step 1) you can use the `-sd` or `--sub-dir` flag to inform the script to search sub directories
+1.  Open a shell/powershell terminal.
+
+2.  Change directory to the directory that contains your folder structure (e.g. `One Piece [tvdb4-81797]`)
+
+3.  (optional) Copy the `rename.py` and `episodes-reference.json` and `chapters-reference.json` file in that directory
+
+4.  Run the script in dry-run mode with the subdirectory flag to see what change would occur
+
+    1.  If you did step 3: `python rename.py -sd --dry-run`
+    2.  Or specify directory `python rename.py -d "/path/to/one/pace/files" -sd --dry-run`
+
+5.  Once you are okay with the changes you see, remove the `--dry-run` flag from the command and run it again.
+    Your files will be renamed to the corresponding One Piece epidode, eg:
+    - `[One Pace][3-5] Romance Dawn 03 [1080p][F5E73C4E].mkv` --> `One.Piece.E3.1080p.mkv`
+    - `[One Pace][677-678] Punk Hazard 12 [720p][CD83F1E9].mkkv` --> `One.Piece.E603-E604.720p.mkv`
+    - `[One Pace] Chapter 700-701 [720p][2A35B710].mkv` -> `One.Piece.E628-E630.720p.mkv`
 
 ### 3. Plex library
 1.  Make sure the Plex library that has One Piece in it uses ASS as the scanner and HAMA as the agent. Scan the library.

--- a/rename.py
+++ b/rename.py
@@ -116,8 +116,7 @@ def main():
     
     for file in video_files:
         try:
-            #new_episode_name = generate_new_name_for_episode(basename(file))
-            new_episode_name = "test"+(basename(file))
+            new_episode_name = generate_new_name_for_episode(basename(file))
             new_episode_path = join(dirname(file),new_episode_name)
         except ValueError as e:
             print(e)

--- a/rename.py
+++ b/rename.py
@@ -92,7 +92,7 @@ def main():
     parser.add_argument("-crf", "--chapter-reference-file", nargs='?', help="Path to the chapters reference file", default="chapters-reference.json")
     parser.add_argument("-d", "--directory", nargs='?', help="Data directory (aka path where the mkv files are)", default=None)
     parser.add_argument("--dry-run", action="store_true", help="If this flag is passed, the output will only show how the files would be renamed")
-    parser.add_argument("-sd", "--sub-dir", action="store_true", help="If this flag is passed, the script will search for mkv files in subdirectories as well")
+    parser.add_argument("-r", "--recurse", action="store_true", help="If this flag is passed, the script will search for mkv files in subdirectories as well")
     args = vars(parser.parse_args())
 
 
@@ -104,7 +104,7 @@ def main():
     set_mapping(load_json_file(episodes_ref_file), load_json_file(chapters_ref_file))
 
     video_files = list_mkv_files_in_directory(args["directory"])
-    if args["sub_dir"]: # check if subdirectories should be searched
+    if args["recurse"]: # check if subdirectories should be searched
         for root, dirs, files in walk(args["directory"]): # find all items in directory
             for dir in dirs: # loop through directories
                 video_files += list_mkv_files_in_directory(join(root, dir)) # add all mkv files in directory to list

--- a/rename.py
+++ b/rename.py
@@ -1,5 +1,5 @@
 from os import listdir, rename, getcwd, walk
-from os.path import isfile, join, abspath, basename, dirname
+from os.path import isfile, join, abspath, basename, dirname, relpath
 import re
 import json
 import argparse
@@ -116,17 +116,22 @@ def main():
     
     for file in video_files:
         try:
-            new_episode_name = generate_new_name_for_episode(basename(file))
+            #new_episode_name = generate_new_name_for_episode(basename(file))
+            new_episode_name = "test"+(basename(file))
             new_episode_path = join(dirname(file),new_episode_name)
         except ValueError as e:
             print(e)
             continue
-
+        
+        #create some shorter file names for printing purposes        
+        short_file = relpath(file,args["directory"])
+        short_new_episode_path = relpath(new_episode_path,args["directory"])
+        
         if args["dry_run"]:
-            print("DRYRUN: \"{}\" -> \"{}\"".format(file, new_episode_path))
+            print("DRYRUN: \"{}\" -> \"{}\"".format(short_file, short_new_episode_path))
             continue
         
-        print(f"Renaming \"{file}\" to \"{new_episode_path}\"")
+        print(f"Renaming \"{short_file}\" to \"{short_new_episode_path}\"")
         rename(file, new_episode_path)
 
 if __name__ == "__main__":

--- a/rename.py
+++ b/rename.py
@@ -36,6 +36,13 @@ def load_json_file(file):
 
     return episode_mapping
 
+def get_files_from_directories(directory, recurse=False):
+    video_files = list_mkv_files_in_directory(directory)
+    if recurse: # check if subdirectories should be searched
+        for root, dirs, files in walk(directory): # find all items in directory
+            for dir in dirs: # loop through directories
+                video_files += get_files_from_directories(join(root, dir), recurse) # add files from subdirectories to list
+    return video_files
 
 # list_mkv_files_in_directory returns all the files in the specified
 # directory that have the .mkv extention
@@ -103,11 +110,7 @@ def main():
 
     set_mapping(load_json_file(episodes_ref_file), load_json_file(chapters_ref_file))
 
-    video_files = list_mkv_files_in_directory(args["directory"])
-    if args["recurse"]: # check if subdirectories should be searched
-        for root, dirs, files in walk(args["directory"]): # find all items in directory
-            for dir in dirs: # loop through directories
-                video_files += list_mkv_files_in_directory(join(root, dir)) # add all mkv files in directory to list
+    video_files = get_files_from_directories(args["directory"], args["recurse"])
 
     if len(video_files) == 0:
         print("No mkv files found in directory \"{}\"".format(args["directory"]))

--- a/rename.py
+++ b/rename.py
@@ -118,17 +118,17 @@ def main():
     for file in video_files:
         try:
             new_episode_name = generate_new_name_for_episode(basename(file))
-            new_episode_name = join(dirname(file),new_episode_name)
+            new_episode_path = join(dirname(file),new_episode_name)
         except ValueError as e:
             print(e)
             continue
 
         if args["dry_run"]:
-            print("DRYRUN: \"{}\" -> \"{}\"".format(file, new_episode_name))
+            print("DRYRUN: \"{}\" -> \"{}\"".format(file, new_episode_path))
             continue
         
-        print(f"Renaming \"{file}\" to \"{new_episode_name}\"")
-        rename(file, new_episode_name)
+        print(f"Renaming \"{file}\" to \"{new_episode_path}\"")
+        rename(file, new_episode_path)
 
 if __name__ == "__main__":
     main()

--- a/rename.py
+++ b/rename.py
@@ -39,9 +39,10 @@ def load_json_file(file):
 def get_files_from_directories(directory, recurse=False):
     video_files = list_mkv_files_in_directory(directory)
     if recurse: # check if subdirectories should be searched
-        for root, dirs, files in walk(directory): # find all items in directory
-            for dir in dirs: # loop through directories
-                video_files += get_files_from_directories(join(root, dir), recurse) # add files from subdirectories to list
+        subdirs = [x[0] for x in walk(directory)] #recursively get all subdirectories
+        #print(subdirs)
+        for dir in subdirs[1:]: # loop through directories, skipping the first one (the root directory) as it's already done
+            video_files += list_mkv_files_in_directory(dir)
     return video_files
 
 # list_mkv_files_in_directory returns all the files in the specified

--- a/rename.py
+++ b/rename.py
@@ -1,6 +1,5 @@
 from os import listdir, rename, getcwd, walk
 from os.path import isfile, join, abspath, basename, dirname
-from sys import exit
 import re
 import json
 import argparse


### PR DESCRIPTION
Add -sd or --sub-dir argument to allow the script to search through the one pace folder structure (e.g.  "Arc 01 - Romance Dawn/file.mkv")

Changed some variables to be file paths instead of file names to facilitate the change

Updated README with instructions on how to use it.