### PR TITLE
Allow whitespace in filename

### DIFF
--- a/Tests/Tests.py
+++ b/Tests/Tests.py
@@ -119,6 +119,10 @@ class TestRenameFunctions(unittest.TestCase):
         new_name = rename.generate_new_name_for_episode(filename)
         assert new_name=="One.Piece.E603-E604.720p.mkv"
         
+        filename = "[One Pace] [677-678] Punk Hazard 12 [720p][CD83F1E9].mkv"
+        new_name = rename.generate_new_name_for_episode(filename)
+        assert new_name=="One.Piece.E603-E604.720p.mkv"
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/rename.py
+++ b/rename.py
@@ -62,7 +62,7 @@ def list_mkv_files_in_directory(directory):
 # and tries to match it with the reference episodes. 
 # It returns the new name the file should have
 def generate_new_name_for_episode(original_file_name):
-    reg = re.search(r'\[One Pace\]\[.*\] (.*?) (\d\d?) \[(\d+p)\].*\.mkv', original_file_name)
+    reg = re.search(r'\[One Pace\]\s*\[.*\] (.*?) (\d\d?) \[(\d+p)\].*\.mkv', original_file_name)
 
     if (reg is not None):
         arc_name = reg.group(1)


### PR DESCRIPTION
My files had the following format which resulted in the regex not matching.
`[One Pace] [0104-0105] Reverse Mountain 02 [480p] [775B819E].mkv`

This change fixes the regex to allow optional whitespace after `[One Pace]`